### PR TITLE
修改公式段的错误标记

### DIFF
--- a/docs/10.md
+++ b/docs/10.md
@@ -7,12 +7,10 @@
 
 朴素贝叶斯方法是基于贝叶斯定理的一组有监督学习算法，即“简单”地假设每对特征之间相互独立。 给定一个类别 ![y](img/0775c03fc710a24df297dedcec515aaf.jpg) 和一个从 ![x_1](img/f15b9946d9078749f894a78579dc6778.jpg) 到 ![x_n](img/14f6506599a88a5297ea712fa70eece4.jpg) 的相关的特征向量， 贝叶斯定理阐述了以下关系:
 
-```py
 
 ![P(y \mid x_1, \dots, x_n) = \frac{P(y) P(x_1, \dots x_n \mid y)}
                                  {P(x_1, \dots, x_n)}](img/32f500a4e2eba65727c1e003699dff90.jpg)
 
-```
 
 使用简单(naive)的假设-每对特征之间都相互独立:
 
@@ -20,24 +18,18 @@
 
 对于所有的 :math: &lt;cite&gt;i&lt;/cite&gt; ，这个关系式可以简化为
 
-```py
 
 ![P(y \mid x_1, \dots, x_n) = \frac{P(y) \prod_{i=1}^{n} P(x_i \mid y)}
                                  {P(x_1, \dots, x_n)}](img/1c12ea7ea179efd16ce513645034d41a.jpg)
 
-```
 
 由于在给定的输入中 ![P(x_1, \dots, x_n)](img/03dc262433e357325639af531c5bf70e.jpg) 是一个常量，我们使用下面的分类规则:
 
-```py
 
 ![P(y \mid x_1, \dots, x_n) \propto P(y) \prod_{i=1}^{n} P(x_i \mid y)
-
 \Downarrow
-
 \hat{y} = \arg\max_y P(y) \prod_{i=1}^{n} P(x_i \mid y),](img/983133e80141fbf289a10f379c11b34f.jpg)
 
-```
 
 我们可以使用最大后验概率(Maximum A Posteriori, MAP) 来估计 ![P(y)](img/d41288778c3d66bcae947c3078469126.jpg) 和 ![P(x_i \mid y)](img/db23fadfab6b660dbfa2934c4536beb1.jpg) ; 前者是训练集中类别 ![y](img/0775c03fc710a24df297dedcec515aaf.jpg) 的相对频率。
 

--- a/docs/11.md
+++ b/docs/11.md
@@ -216,22 +216,17 @@ scikit-learn 使用 CART 算法的优化版本。
 
 将 ![m](img/94156b879a7455cb0d516efa9c9c0991.jpg) 节点上的数据用 ![Q](img/87dfb2676632ee8a92713f4861ccc84e.jpg) 来表示。每一个候选组 ![\theta = (j, t_m)](img/c3567127ff1f678758b338a50e9c4880.jpg) 包含一个特征 ![j](img/7b215f2882ce8aaa33a97e43ad626314.jpg) 和阈值 ![t_m](img/264dc5b617a5aa98151c4ea6975e9a90.jpg) 将,数据分成 ![Q_{left}(\theta)](img/32246af90101d1607825a589ebea6880.jpg) 和 ![Q_{right}(\theta)](img/6c70b46b88f05e00e292f1a0f98d2aa8.jpg) 子集。
 
-```py
 
 ![Q_{left}(\theta) = {(x, y) | x_j &lt;= t_m}
-
 Q_{right}(\theta) = Q \setminus Q_{left}(\theta)](img/d5a26fae0e652d4e951d9ec9ae1a01e5.jpg)
 
-```
 
 使用不纯度函数 ![H()](img/b382a1d99ddfadf17b35d32b0b156b5b.jpg) 计算 ![m](img/94156b879a7455cb0d516efa9c9c0991.jpg) 处的不纯度,其选择取决于正在解决的任务（分类或回归）
 
-```py
 
 ![G(Q, \theta) = \frac{n_{left}}{N_m} H(Q_{left}(\theta))
 + \frac{n_{right}}{N_m} H(Q_{right}(\theta))](img/c57c1c5b116586e218fdaa3d0696d246.jpg)
 
-```
 
 选择使不纯度最小化的参数
 
@@ -265,23 +260,17 @@ Cross-Entropy （交叉熵）
 
 Mean Squared Error （均方误差）:
 
-```py
 
 ![c_m = \frac{1}{N_m} \sum_{i \in N_m} y_i
-
 H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} (y_i - c_m)^2](img/0cd05229735908f0f99e59deb90a4434.jpg)
 
-```
 
 Mean Absolute Error（平均绝对误差）:
 
-```py
 
 ![\bar{y_m} = \frac{1}{N_m} \sum_{i \in N_m} y_i
-
 H(X_m) = \frac{1}{N_m} \sum_{i \in N_m} |y_i - \bar{y_m}|](img/3b70a99c882760b6d8ed230e145ed742.jpg)
 
-```
 
 在 ![X_m](img/fe5ed835e0d3407e3f2d694d8bc049a1.jpg) 训练 ![m](img/94156b879a7455cb0d516efa9c9c0991.jpg) 节点上的数据时。
 

--- a/docs/18.md
+++ b/docs/18.md
@@ -140,12 +140,10 @@ array([[0, 1]])
 
 MLP 使用 [Stochastic Gradient Descent（随机梯度下降）(SGD)](https://en.wikipedia.org/wiki/Stochastic_gradient_descent), [Adam](http://arxiv.org/abs/1412.6980), 或者 [L-BFGS](https://en.wikipedia.org/wiki/Limited-memory_BFGS) 进行训练。 随机梯度下降（SGD） 使用关于需要适应的一个参数的损失函数的梯度来更新参数，即
 
-```py
 
 ![w \leftarrow w - \eta (\alpha \frac{\partial R(w)}{\partial w}
 + \frac{\partial Loss}{\partial w})](img/cdc5ef75d769259ef0537940296ab0b4.jpg)
 
-```
 
 其中 ![\eta](img/fe1d79339349f9b6263e123094ffce7b.jpg) 是控制训练过程参数更新步长的学习率（learning rate）。 ![Loss](img/16622481c2bbb001363e20660b549ae9.jpg) 是损失函数（loss function）。
 

--- a/docs/2.md
+++ b/docs/2.md
@@ -201,12 +201,10 @@ scikit-learn 通过交叉验证来公开设置 Lasso `alpha` 参数的对象: [`
 
 在这里，最小化的目标函数是
 
-```py
 
 ![\underset{w}{min\,} { \frac{1}{2n_{samples}} ||X w - y||_2 ^ 2 + \alpha \rho ||w||_1 +
 \frac{\alpha(1-\rho)}{2} ||w||_2 ^ 2}](img/9b9ee41d276ad49322856b95cb6c7e43.jpg)
 
-```
 
 ![https://scikit-learn.org/stable/_images/sphx_glr_plot_lasso_coordinate_descent_path_001.png:target:../auto_examples/linear_model/plot_lasso_coordinate_descent_path.html:align:center:scale:50%](../Images/aa0c61cd560f0fdab4fe10c7b12e5082.jpg)
 
@@ -223,12 +221,10 @@ scikit-learn 通过交叉验证来公开设置 Lasso `alpha` 参数的对象: [`
 
 从数学上来说， 它包含一个混合的 ![\ell_1](img/3bf32d926cdf24f440b6b831f0d9cc37.jpg) ![\ell_2](img/8851bd0fe9749b4841b30cee41fb040d.jpg) 先验和 ![\ell_2](img/8851bd0fe9749b4841b30cee41fb040d.jpg) 先验为正则项训练的线性模型 目标函数就是最小化:
 
-```py
 
 ![\underset{W}{min\,} { \frac{1}{2n_{samples}} ||X W - Y||_{Fro}^2 + \alpha \rho ||W||_{2 1} +
 \frac{\alpha(1-\rho)}{2} ||W||_{Fro}^2}](img/a1670c1fcb5b7ad10830f43812ed50da.jpg)
 
-```
 
 在 [`MultiTaskElasticNet`](generated/sklearn.linear_model.MultiTaskElasticNet.html#sklearn.linear_model.MultiTaskElasticNet "sklearn.linear_model.MultiTaskElasticNet") 类中的实现采用了坐标下降法求解参数。
 
@@ -294,21 +290,17 @@ Lars 算法提供了一个几乎无代价的沿着正则化参数的系数的完
 
 就像最小角回归一样，作为一个前向特征选择方法，正交匹配追踪法可以近似一个固定非 0 元素的最优向量解:
 
-```py
 
 ![\text{arg\,min\,} ||y - X\gamma||_2^2 \text{ subject to } \
 ||\gamma||_0 \leq n_{nonzero\_coefs}](img/ed70b000f50fb169ffe20ca2979e4a75.jpg)
 
-```
 
 正交匹配追踪法也可以针对一个特殊的误差而不是一个特殊的非零系数的个数。可以表示为:
 
-```py
 
 ![\text{arg\,min\,} ||\gamma||_0 \text{ subject to } ||y-X\gamma||_2^2 \
 \leq \text{tol}](img/6b7248d635f4161b925734dbc60de37a.jpg)
 
-```
 
 OMP 是基于每一步的贪心算法，其每一步元素都是与当前残差高度相关的。它跟较为简单的匹配追踪（MP）很相似，但是相比 MP 更好，在每一次迭代中，可以利用正交投影到之前选择的字典元素重新计算残差。
 
@@ -351,12 +343,10 @@ Alpha 在这里也是作为一个变量，通过数据中估计得到。
 
 > [`BayesianRidge`](generated/sklearn.linear_model.BayesianRidge.html#sklearn.linear_model.BayesianRidge "sklearn.linear_model.BayesianRidge") 利用概率模型估算了上述的回归问题，其先验参数 ![w](img/8a58e8df6a985a3273e39bac7dd72b1f.jpg) 是由以下球面高斯公式得出的：
 
-```py
 
 ![p(w|\lambda) =
 \mathcal{N}(w|0,\lambda^{-1}\bold{I_{p}})](img/971b86cde9801a3bb1a80af70bd05466.jpg)
 
-```
 
 先验参数 ![\alpha](img/d8b3d5242d513369a44f8bf0c6112744.jpg) 和 ![\lambda](img/0f92bc682b050115d03c625ce770c77d.jpg) 一般是服从 [gamma 分布](https://en.wikipedia.org/wiki/Gamma_distribution) ， 这个分布与高斯成共轭先验关系。
 
@@ -663,14 +653,12 @@ scikit-learn 中实现的 [`TheilSenRegressor`](generated/sklearn.linear_model.T
 
 其中
 
-```py
 
 ![H_m(z) = \begin{cases}
        z^2, & \text {if } |z| &lt; \epsilon, \\
        2\epsilon|z| - \epsilon^2, & \text{otherwise}
 \end{cases}](img/37e4251726a37bc02df4ef4390572e9a.jpg)
 
-```
 
 建议设置参数 `epsilon` 为 1.35 以实现 95% 统计效率。
 

--- a/docs/22.md
+++ b/docs/22.md
@@ -573,14 +573,12 @@ mutual information 的价值以及 normalized variant （标准化变量）的�
 
 mutual information 的期望值可以用 Vinh, Epps 和 Bailey,(2009) 的以下公式来计算。在这个方程式中, ![a_i = |U_i|](img/f3893160388ee4203c313659d729cef0.jpg) (![U_i](img/59100a001bb4b110e00f7ddf1354cd5b.jpg) 中元素的数量) 和 ![b_j = |V_j|](img/e2bd3aaa1586d4d17301f7fe016eefd7.jpg) (![V_j](img/22f3a10ad9acceb77ea6193f945b11cf.jpg) 中元素的数量).
 
-```py
 
 ![E[\text{MI}(U,V)]=\sum_{i=1}^|U| \sum_{j=1}^|V| \sum_{n_{ij}=(a_i+b_j-N)^+
 }^{\min(a_i, b_j)} \frac{n_{ij}}{N}\log \left( \frac{ N.n_{ij}}{a_i b_j}\right)
 \frac{a_i!b_j!(N-a_i)!(N-b_j)!}{N!n_{ij}!(a_i-n_{ij})!(b_j-n_{ij})!
 (N-a_i-b_j+n_{ij})!}](img/942734d190e4b1d2c51b0e2ee6c24428.jpg)
 
-```
 
 使用期望值, 然后可以使用与 adjusted Rand index 相似的形式来计算调整后的 mutual information:
 
@@ -688,12 +686,10 @@ Homogeneity（同质性） 和 completeness（完整性） 的得分由下面公
 
 其中 ![H(C|K)](img/c9f28da3986a32d6c1421f357d52b9fa.jpg) 是 **给定簇分配的类的 conditional entropy （条件熵）** ，由下式给出:
 
-```py
 
 ![H(C|K) = - \sum_{c=1}^{|C|} \sum_{k=1}^{|K|} \frac{n_{c,k}}{n}
 \cdot \log\left(\frac{n_{c,k}}{n_k}\right)](img/e18ade3134bef595ea6ddf488ff9557a.jpg)
 
-```
 
 并且 ![H(C)](img/be4190a760361bd7ae65c77218465778.jpg) 是 **entropy of the classes（类的熵）**，并且由下式给出:
 

--- a/docs/23.md
+++ b/docs/23.md
@@ -73,13 +73,11 @@ Note
 
 ![\ell = \lceil \log_2 k \rceil](img/5e45807b4775fcfaca64f6363102dc5e.jpg) 奇异值向量从第二个开始, 提供所需的分区信息。 这些用于形成矩阵 :&lt;cite&gt;Z&lt;/cite&gt;:
 
-```py
 
 ![Z = \begin{bmatrix} R^{-1/2} U \\\\
                     C^{-1/2} V
       \end{bmatrix}](img/33d1bf322bf0f6046a1145dbc264803b.jpg)
 
-```
 
 ![U](img/11c00539ec3e5944afd76511830591db.jpg) 的列是 ![u_2, \dots, u_{\ell +1}](img/1fc7cc5cbdba693962c7708456165810.jpg), 和 ![V](img/5303ecbc70bf5189b8785555c03c54ee.jpg) 相似 。
 
@@ -115,12 +113,10 @@ Note
     \log A](img/515ee7781876d7344cc383bb43cb30ea.jpg). 列就是 ![\overline{L_{i \cdot}}](img/7ba11d33e68a1e32f2d8d9387bbc1eba.jpg), 行就是 ![\overline{L_{\cdot j}}](img/dc8f095e63b3defdb85fcf54d7d2d8c2.jpg), 总体上来看 ![\overline{L_{\cdot
     \cdot}}](img/a0bb00db4979d538e9ca2f0a8b423286.jpg) of ![L](img/639e82f3829a0ad677110cc33a028c98.jpg) 被计算的. 最后矩阵通过下面的公式计算
 
-```py
 
 ![K_{ij} = L_{ij} - \overline{L_{i \cdot}} - \overline{L_{\cdot
 j}} + \overline{L_{\cdot \cdot}}](img/d670eea3215462f64d74d9366622a490.jpg)
 
-```
 
 归一化后，首先少量的奇异值向量被计算，只是在 Spectral Co-Clustering 算法中。
 

--- a/docs/24.md
+++ b/docs/24.md
@@ -104,14 +104,12 @@ Principal component analysis（主成分分析） ([`PCA`](generated/sklearn.dec
 
 请注意，有多种不同的计算稀疏PCA 问题的公式。 这里使用的方法基于 [[Mrl09]](#mrl09) 。优化问题的解决是一个带有惩罚项（L1范数的） ![\ell_1](img/3bf32d926cdf24f440b6b831f0d9cc37.jpg) 的一个 PCA 问题（dictionary learning（字典学习））:
 
-```py
 
 ![(U^*, V^*) = \underset{U, V}{\operatorname{arg\,min\,}} & \frac{1}{2}
              ||X-UV||_2^2+\alpha||V||_1 \\
              \text{subject to\,} & ||U_k||_2 = 1 \text{ for all }
              0 \leq k &lt; n_{components}](img/d6d6e6638cd01ead4811579660e36b44.jpg)
 
-```
 
 导致稀疏（sparsity-inducing）的 ![\ell_1](img/3bf32d926cdf24f440b6b831f0d9cc37.jpg) 规范也可以避免当训练样本很少时从噪声中学习成分。可以通过超参数 `alpha` 来调整惩罚程度（从而减少稀疏度）。值较小会导致温和的正则化因式分解，而较大的值将许多系数缩小到零。
 
@@ -195,14 +193,12 @@ Note
 
 词典学习是通过交替更新稀疏编码来解决的优化问题，作为解决多个 Lasso 问题的一个解决方案，考虑到字典固定，然后更新字典以最好地适合稀疏编码。
 
-```py
 
 ![(U^*, V^*) = \underset{U, V}{\operatorname{arg\,min\,}} & \frac{1}{2}
              ||X-UV||_2^2+\alpha||U||_1 \\
              \text{subject to\,} & ||V_k||_2 = 1 \text{ for all }
              0 \leq k &lt; n_{\mathrm{atoms}}](img/9b4b00422c0cec29f80a03fe1d772100.jpg)
 
-```
 
 **[![pca_img2](../Images/9a55689143b2e4d90adcdfe1f95b9ffd.jpg)](../auto_examples/decomposition/plot_faces_decomposition.html) [![dict_img2](../Images/86f7969b00fb3d0914f0bababac102a0.jpg)](../auto_examples/decomposition/plot_faces_decomposition.html)**
 
@@ -321,24 +317,20 @@ Unlike [`PCA`](generated/sklearn.decomposition.PCA.html#sklearn.decomposition.PC
 
 在 [`NMF`](generated/sklearn.decomposition.NMF.html#sklearn.decomposition.NMF "sklearn.decomposition.NMF") 中，L1 和 L2 先验可以被添加到损失函数中以使模型正规化。 L2 先验使用 Frobenius 范数，而L1 先验使用 L1 范数。与 `ElasticNet` 一样， 我们通过 `l1_ratio` (![\rho](img/b91e4507d9fd7068b02f689d697f8714.jpg)) 参数和正则化强度参数 `alpha` (![\alpha](img/d8b3d5242d513369a44f8bf0c6112744.jpg)) 来控制 L1 和 L2 的组合。那么先验项是:
 
-```py
 
 ![\alpha \rho ||W||_1 + \alpha \rho ||H||_1
 + \frac{\alpha(1-\rho)}{2} ||W||_{\mathrm{Fro}} ^ 2
 + \frac{\alpha(1-\rho)}{2} ||H||_{\mathrm{Fro}} ^ 2](img/be8c80153a3cafbe4309f1fe3b62d96b.jpg)
 
-```
 
 正则化目标函数为:
 
-```py
 
 ![d_{\mathrm{Fro}}(X, WH)
 + \alpha \rho ||W||_1 + \alpha \rho ||H||_1
 + \frac{\alpha(1-\rho)}{2} ||W||_{\mathrm{Fro}} ^ 2
 + \frac{\alpha(1-\rho)}{2} ||H||_{\mathrm{Fro}} ^ 2](img/2c1da71c882c95ba6660cdad0d976f6d.jpg)
 
-```
 
 [`NMF`](generated/sklearn.decomposition.NMF.html#sklearn.decomposition.NMF "sklearn.decomposition.NMF") 正则化 W 和 H . 公共函数 `non_negative_factorization` 允许通过 `regularization` 属性进行更精细的控制，将 仅W ，仅H 或两者正规化。
 
@@ -419,21 +411,17 @@ LDA 的图形模型是一个三层贝叶斯模型:
 
 对于参数估计，后验分布为:
 
-```py
 
 ![p(z, \theta, \beta |w, \alpha, \eta) =
   \frac{p(z, \theta, \beta|\alpha, \eta)}{p(w|\alpha, \eta)}](img/5d0c433dc4dc7ca883ac8173e6e2096f.jpg)
 
-```
 
 由于后验分布难以处理，变体贝叶斯方法使用更简单的分布 ![q(z,\theta,\beta | \lambda, \phi, \gamma)](img/8fae035cff5a2ccfbc80e38fab4907cd.jpg) 近似， 并且优化了这些变体参数 ![\lambda](img/0f92bc682b050115d03c625ce770c77d.jpg), ![\phi](img/ff5e98366afa13070d3b410c55a80db1.jpg), ![\gamma](img/6552bde3d3999c1a9728016416932af7.jpg) 最大化Evidence Lower Bound (ELBO):
 
-```py
 
 ![\log\: P(w | \alpha, \eta) \geq L(w,\phi,\gamma,\lambda) \overset{\triangle}{=}
   E_{q}[\log\:p(w,z,\theta,\beta|\alpha,\eta)] - E_{q}[\log\:q(z, \theta, \beta)]](img/6d8b62cf31afb168e2b2acb89d6abccd.jpg)
 
-```
 
 最大化 ELBO 相当于最小化 ![q(z,\theta,\beta)](img/2c2dcc83fc38e46810a36e59b2614a5c.jpg) 和后验 ![p(z, \theta, \beta |w, \alpha, \eta)](img/7efe29500f4af973643a15b3ed29a926.jpg) 之间的 Kullback-Leibler(KL) 散度。
 

--- a/docs/28.md
+++ b/docs/28.md
@@ -21,14 +21,12 @@ Note
 
 数学公式如下：
 
-```py
 
 ![\hat{K} = \mathrm{argmin}_K \big(
             \mathrm{tr} S K - \mathrm{log} \mathrm{det} K
             + \alpha \|K\|_1
             \big)](img/43996aff9311511e6e2f81912a249c7e.jpg)
 
-```
 
 其中：![K](img/e279b8169ddd6581c5606c868ba52fae.jpg) 是要估计的精度矩阵（precision matrix）， ![S](img/12ecd862769bee1e71c75c134b6423bb.jpg) 是样本的协方差矩阵。 ![\|K\|_1](img/6122e23454910f4f076c71a84c068291.jpg) 是非对角系数 ![K](img/e279b8169ddd6581c5606c868ba52fae.jpg) （off-diagonal coefficients）的绝对值之和。 用于解决这个问题的算法是来自 Friedman 2008 Biostatistics 论文的 GLasso 算法。 它与 R 语言 `glasso` 包中的算法相同。
 

--- a/docs/32.md
+++ b/docs/32.md
@@ -29,12 +29,10 @@ RBM 的图形模型是一个全连接的二分图（fully-connected bipartite gr
 
 节点是随机变量，其状态取决于它连接到的其他节点的状态。 因此，为了简单起见，模型被参数化为连接的权重以及每个可见和隐藏单元的一个偏置项。 我们用能量函数衡量联合概率分布的质量:
 
-```py
 
 ![E(\mathbf{v}, \mathbf{h}) = \sum_i \sum_j w_{ij}v_ih_j + \sum_i b_iv_i
   + \sum_j c_jh_j](img/5959a6fe3c27570b7d474f26126eb628.jpg)
 
-```
 
 在上面的公式中， ![\mathbf{b}](img/4dee38783cbd4faef5d5639ce23a5c59.jpg) 和 ![\mathbf{c}](img/a4dd5119f3eeb13b99180aab64917975.jpg) 分别是可见层和隐藏层的偏置向量。 模型的联合概率是根据能量来定义的:
 
@@ -42,12 +40,10 @@ RBM 的图形模型是一个全连接的二分图（fully-connected bipartite gr
 
 “限制”是指模型的二分图结构，它禁止隐藏单元之间或可见单元之间的直接交互。 这代表以下条件独立性成立:
 
-```py
 
 ![h_i \bot h_j | \mathbf{v} \\
 v_i \bot v_j | \mathbf{h}](img/9521899a181a367c5873e61b9f7785ce.jpg)
 
-```
 
 二分图结构允许使用高效的块吉比斯采样(block Gibbs sampling)进行推断。
 
@@ -57,12 +53,10 @@ v_i \bot v_j | \mathbf{h}](img/9521899a181a367c5873e61b9f7785ce.jpg)
 
 每个单位的条件概率分布由其接收的输入的sigmoid函数给出:
 
-```py
 
 ![P(v_i=1|\mathbf{h}) = \sigma(\sum_j w_{ij}h_j + b_i) \\
 P(h_i=1|\mathbf{v}) = \sigma(\sum_i w_{ij}v_i + c_j)](img/e6811d3f6333e9490d602db8dc1e3d96.jpg)
 
-```
 
 其中 ![\sigma](img/8c4a5c99b21079b9fb1be49910ff96e3.jpg) 是Sigmoid函数:
 

--- a/docs/5.md
+++ b/docs/5.md
@@ -341,25 +341,19 @@ array([0, 1])
 
 在两类中，给定训练向量 ![x_i \in \mathbb{R}^p](img/2bd24ed32bcf24db79058c3cc81f5331.jpg), i=1,…, n, 和一个向量 ![y \in \{1, -1\}^n](img/73658f99647e50786817b44416d09df1.jpg), SVC能解决 如下主要问题:
 
-```py
 
 ![\min_ {w, b, \zeta} \frac{1}{2} w^T w + C \sum_{i=1}^{n} \zeta_i
-
 \textrm {subject to } & y_i (w^T \phi (x_i) + b) \geq 1 - \zeta_i,\\
 & \zeta_i \geq 0, i=1, ..., n](img/ee78ab463ea8dc72594f270f5193a7a6.jpg)
 
-```
 
 它的对偶是
 
-```py
 
 ![\min_{\alpha} \frac{1}{2} \alpha^T Q \alpha - e^T \alpha
-
 \textrm {subject to } & y^T \alpha = 0\\
 & 0 \leq \alpha_i \leq C, i=1, ..., n](img/61b05c3bf030b831f23f257ca8182f51.jpg)
 
-```
 
 其中 ![e](img/1f9000a4bf057edcb9b87d7a4abb8e8d.jpg) 是所有的向量， ![C &gt; 0](img/2edeef5a5007d4bd8b4f43fe2670cf85.jpg) 是上界，![Q](img/87dfb2676632ee8a92713f4861ccc84e.jpg) 是一个 ![n](img/c87d9110f3d32ffa5fa08671e4af11fb.jpg) 由 ![n](img/c87d9110f3d32ffa5fa08671e4af11fb.jpg) 个半正定矩阵， 而 ![Q_{ij} \equiv y_i y_j K(x_i, x_j)](img/36c2dba9ae7680cd09eff62c73e37963.jpg) ，其中 ![K(x_i, x_j) = \phi (x_i)^T \phi (x_j)](img/51fa9007646861e0569f8f66731c64e7.jpg) 是内核。所以训练向量是通过函数 ![\phi](img/ff5e98366afa13070d3b410c55a80db1.jpg)，间接反映到一个更高维度的（无穷的）空间。
 
@@ -389,26 +383,20 @@ array([0, 1])
 
 给定训练向量 ![x_i \in \mathbb{R}^p](img/2bd24ed32bcf24db79058c3cc81f5331.jpg), i=1,…, n，向量 ![y \in \mathbb{R}^n](img/6653de9b4dea7e5e9a897b5f34e7a4f0.jpg) ![\varepsilon](img/bf9fb1354c2e0ea50d37e5cad7866314.jpg)-SVR 能解决以下的主要问题：
 
-```py
 
 ![\min_ {w, b, \zeta, \zeta^*} \frac{1}{2} w^T w + C \sum_{i=1}^{n} (\zeta_i + \zeta_i^*)
-
 \textrm {subject to } & y_i - w^T \phi (x_i) - b \leq \varepsilon + \zeta_i,\\
                       & w^T \phi (x_i) + b - y_i \leq \varepsilon + \zeta_i^*,\\
                       & \zeta_i, \zeta_i^* \geq 0, i=1, ..., n](img/23dac8b2be31a1cbe914b59ff2670dbf.jpg)
 
-```
 
 它的对偶是
 
-```py
 
 ![\min_{\alpha, \alpha^*} \frac{1}{2} (\alpha - \alpha^*)^T Q (\alpha - \alpha^*) + \varepsilon e^T (\alpha + \alpha^*) - y^T (\alpha - \alpha^*)
-
 \textrm {subject to } & e^T (\alpha - \alpha^*) = 0\\
 & 0 \leq \alpha_i, \alpha_i^* \leq C, i=1, ..., n](img/e996da94de858e5248f145e01733ed9d.jpg)
 
-```
 
 其中 ![e](img/1f9000a4bf057edcb9b87d7a4abb8e8d.jpg) 是所有的向量， ![C &gt; 0](img/2edeef5a5007d4bd8b4f43fe2670cf85.jpg) 是上界，![Q](img/87dfb2676632ee8a92713f4861ccc84e.jpg) 是一个 ![n](img/c87d9110f3d32ffa5fa08671e4af11fb.jpg) 由 ![n](img/c87d9110f3d32ffa5fa08671e4af11fb.jpg) 个半正定矩阵， 而 ![Q_{ij} \equiv K(x_i, x_j) = \phi (x_i)^T \phi (x_j)](img/b019b19dda07f07208f1bd2576ebad30.jpg) 是内核。 所以训练向量是通过函数 ![\phi](img/ff5e98366afa13070d3b410c55a80db1.jpg)，间接反映到一个更高维度的（无穷的）空间。
 

--- a/docs/53.md
+++ b/docs/53.md
@@ -676,7 +676,6 @@ Log loss，又被称为 logistic regression loss（logistic 回归损失）或�
 
 然后 multiclass MCC 定义为:
 
-```py
 
 ![MCC = \frac{
     c \times s - \sum_{k}^{K} p_k \times t_k
@@ -685,7 +684,6 @@ Log loss，又被称为 logistic regression loss（logistic 回归损失）或�
     (s^2 - \sum_{k}^{K} t_k^2)
 }}](img/e73c79ca71fe87074008fd5f464d686d.jpg)
 
-```
 
 当有两个以上的标签时， MCC 的值将不再在 -1 和 +1 之间。相反，根据已经标注的真实数据的数量和分布情况，最小值将介于 -1 和 0 之间。最大值始终为 +1 。
 
@@ -845,12 +843,10 @@ Note
 
 正式地，给定真实标签 ![y \in \left\{0, 1\right\}^{n_\text{samples} \times n_\text{labels}}](img/2b0d9f09a2b8a107ace9ce7aa234481e.jpg) 的二进制指示矩阵和与每个标签 ![\hat{f} \in \mathbb{R}^{n_\text{samples} \times n_\text{labels}}](img/d325b0db5d92ebf952f4b6d810fa43bd.jpg) 相关联的分数，覆盖范围被定义为
 
-```py
 
 ![coverage(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
   \sum_{i=0}^{n_{\text{samples}} - 1} \max_{j:y_{ij} = 1} \text{rank}_{ij}](img/fb8da9a6dd6e45015b629002d748d9b1.jpg)
 
-```
 
 与 ![\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|](img/5eea9f6c78020e75b9cc37d038d297ab.jpg) 。给定等级定义，通过给出将被分配给所有绑定值的最大等级， `y_scores` 中的关系会被破坏。
 
@@ -874,13 +870,11 @@ Note
 
 正式地，给定真实标签 ![y \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}](img/e310c621bd78988800b952eb7542cd88.jpg) 的二进制指示矩阵和与每个标签 ![\hat{f} \in \mathcal{R}^{n_\text{samples} \times n_\text{labels}}](img/9255ba83a88cb73b04d1ca968f9c2b4e.jpg) 相关联的得分，平均精度被定义为
 
-```py
 
 ![LRAP(y, \hat{f}) = \frac{1}{n_{\text{samples}}}
   \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{|y_i|}
   \sum_{j:y_{ij} = 1} \frac{|\mathcal{L}_{ij}|}{\text{rank}_{ij}}](img/bec3afcb1362068f9caf79c5c58ea816.jpg)
 
-```
 
 与 ![\mathcal{L}_{ij} = \left\{k: y_{ik} = 1, \hat{f}_{ik} \geq \hat{f}_{ij} \right\}](img/f6ce0899ba52f1169500b726ee9c8a92.jpg)， ![\text{rank}_{ij} = \left|\left\{k: \hat{f}_{ik} \geq \hat{f}_{ij} \right\}\right|](img/5eea9f6c78020e75b9cc37d038d297ab.jpg) 和 ![|\cdot|](img/f7dd5b16c1d8c3e278e9a1fa7f49dcd2.jpg) 是集合的 l0 范数或基数。
 
@@ -902,13 +896,11 @@ Note
 
 正式地，给定真相标签 ![y \in \left\{0, 1\right\}^{n_\text{samples} \times n_\text{labels}}](img/2b0d9f09a2b8a107ace9ce7aa234481e.jpg) 的二进制指示矩阵和与每个标签 ![\hat{f} \in \mathbb{R}^{n_\text{samples} \times n_\text{labels}}](img/d325b0db5d92ebf952f4b6d810fa43bd.jpg) 相关联的得分，排序损失被定义为
 
-```py
 
 ![\text{ranking\_loss}(y, \hat{f}) =  \frac{1}{n_{\text{samples}}}
   \sum_{i=0}^{n_{\text{samples}} - 1} \frac{1}{|y_i|(n_\text{labels} - |y_i|)}
   \left|\left\{(k, l): \hat{f}_{ik} &lt; \hat{f}_{il}, y_{ik} = 1, y_{il} = 0 \right\}\right|](img/eeb2bac86ebedef3d8d2dcbf5b8c735b.jpg)
 
-```
 
 其中 ![|\cdot|](img/f7dd5b16c1d8c3e278e9a1fa7f49dcd2.jpg) 是 ![\ell_0](img/abee3460000f8532d0df4e1b1d1928e8.jpg) 范数或集合的基数。
 

--- a/docs/6.md
+++ b/docs/6.md
@@ -231,12 +231,10 @@ SGD 主要的优势在于它的高效性，对于不同规模的训练样本，�
 
 [`SGDClassifier`](generated/sklearn.linear_model.SGDClassifier.html#sklearn.linear_model.SGDClassifier "sklearn.linear_model.SGDClassifier") 类实现了一个 first-order SGD learning routine （一阶 SGD 学习程序）。 算法在训练样本上遍历，并且对每个样本根据由以下式子给出的更新规则来更新模型参数。
 
-```py
 
 ![w \leftarrow w - \eta (\alpha \frac{\partial R(w)}{\partial w}
 + \frac{\partial L(w^T x_i + b, y_i)}{\partial w})](img/74f4ea0e25b673d30d56ab4269f03f3b.jpg)
 
-```
 
 其中 ![\eta](img/fe1d79339349f9b6263e123094ffce7b.jpg) 是在参数空间中控制步长的 learning rate （学习速率）。 intercept（截距） ![b](img/6ae91fb0f3221b92d2dd4e22204d8008.jpg) 的更新类似但不需要正则化。
 

--- a/docs/61.md
+++ b/docs/61.md
@@ -69,7 +69,6 @@ The [`sklearn.random_projection.GaussianRandomProjection`](generated/sklearn.ran
 
 如果我们定义 `s = 1 / density`, 随机矩阵的元素由
 
-```py
 
 ![\left\{
 \begin{array}{c c l}
@@ -79,7 +78,6 @@ The [`sklearn.random_projection.GaussianRandomProjection`](generated/sklearn.ran
 \end{array}
 \right.](img/3e233cefc937a43bb4481dd23d728b54.jpg)
 
-```
 
 抽取。
 

--- a/docs/71.md
+++ b/docs/71.md
@@ -236,12 +236,10 @@ Lasso(alpha=0.025118864315095794, copy_X=True, fit_intercept=True,
 
 对于分类，比如标定 [鸢尾属植物](https://en.wikipedia.org/wiki/Iris_flower_data_set) 任务，线性回归就不是好方法了，因为它会给数据很多远离决策边界的权值。一个线性方法是为了拟合 sigmoid 函数 或 **logistic** 函数：
 
-```py
 
 ![y = \textrm{sigmoid}(X\beta - \textrm{offset}) + \epsilon =
 \frac{1}{1 + \textrm{exp}(- X\beta + \textrm{offset})} + \epsilon](img/5b84281b8f1a26c9e9cba1b6cb0126ce.jpg)
 
-```
 
 ```py
 >>> logistic = linear_model.LogisticRegression(C=1e5)

--- a/docs/8.md
+++ b/docs/8.md
@@ -317,12 +317,10 @@ GaussianProcess(beta0=None, corr=<function squared_exponential at 0x...>,
 
 假设需要对电脑实验的结果进行建模，例如使用一个数学函数：
 
-```py
 
 ![g: & \mathbb{R}^{n_{\rm features}} \rightarrow \mathbb{R} \\
    & X \mapsto y = g(X)](img/cb598ee06bc5060d2dabe4acba00faa7.jpg)
 
-```
 
 同时假设这个函数是 _一个_ 有关于 _一个_ 高斯过程 ![G](img/fb9cbfd2ff15ac51a36902f0a6037c28.jpg) 的条件采用方法， 那么从这个假设出发，GPML 通常可以表示为如下形式：
 
@@ -344,12 +342,10 @@ GaussianProcess(beta0=None, corr=<function squared_exponential at 0x...>,
 
 我们现在推导出基于观测结果的 _最佳线性无偏预测_ ![g](img/6211fb320c2cdb794a80e9e0b800a6a1.jpg)
 
-```py
 
 ![\hat{G}(X) = G(X | y_1 = g(X_1), ...,
                             y_{n_{\rm samples}} = g(X_{n_{\rm samples}}))](img/47d90c837620a14d53233bae4fe8fe57.jpg)
 
-```
 
 它可以由 _给定的属性_ 加以派生：
 
@@ -363,21 +359,17 @@ GaussianProcess(beta0=None, corr=<function squared_exponential at 0x...>,
 
 *   它是最好的（在均方误差的意义上）
 
-```py
 
 ![\hat{G}(X)^* = \arg \min\limits_{\hat{G}(X)} \;
                                         \mathbb{E}[(G(X) - \hat{G}(X))^2]](img/433674c5864f3cec96b82f9e63b80fb7.jpg)
 
-```
 
 因此最优的带权向量 ![a(X)](img/e3ff277d54a34043adefa98a9e1a69d1.jpg) 是以下等式约束优化问题的解
 
-```py
 
 ![a(X)^* = \arg \min\limits_{a(X)} & \; \mathbb{E}[(G(X) - a(X)^T y)^2] \\
                    {\rm s. t.} & \; \mathbb{E}[G(X) - a(X)^T y] = 0](img/395ca6ce9617a4fc0695db973496d29b.jpg)
 
-```
 
 以拉格朗日形式重写这个受约束的优化问题，并进一步寻求要满足的一阶最优条件， 从而得到一个以闭合形式表达式为终止形式的预测器 - 参见参考文献中完整的证明。
 
@@ -387,7 +379,6 @@ GaussianProcess(beta0=None, corr=<function squared_exponential at 0x...>,
 
 方差为:
 
-```py
 
 ![\sigma_{\hat{Y}}^2(X) = \sigma_{Y}^2\,
 ( 1
@@ -395,7 +386,6 @@ GaussianProcess(beta0=None, corr=<function squared_exponential at 0x...>,
 + u(X)^T\,(F^T\,R^{-1}\,F)^{-1}\,u(X)
 )](img/6fcf3a401454fd3c65ac740912e12467.jpg)
 
-```
 
 其中:
 
@@ -417,12 +407,10 @@ GaussianProcess(beta0=None, corr=<function squared_exponential at 0x...>,
 
 *   和向量:
 
-```py
 
 ![\gamma & = R^{-1}(Y - F\,\hat{\beta}) \\
 u(X) & = F^T\,R^{-1}\,r(X) - f(X)](img/efaeec5dadbe79caddb0f92abab55f5b.jpg)
 
-```
 
 需要重点注意的是，高斯过程预测器的概率输出是完全可分析的并且依赖于基本的线性代数操作。 更准确地说，预测结果的均值是两个简单线性组合（点积）的和，方差需要两个矩阵反转操作，但关联 矩阵只能使用 Cholesky 分解算法分解一次。
 


### PR DESCRIPTION
使用[正则](https://github.com/loopyme/loopyme.github.io/blob/master/_posts/2019-06-01-re.md)批量删除了45个公式段的错误标记 