### PR TITLE
修改内联公式格式，根据Kramdown的格式

### DIFF
--- a/docs/0.21.3/21.md
+++ b/docs/0.21.3/21.md
@@ -202,7 +202,7 @@ MDS算法有2类：度量和非度量。在 scikit-learn 中， [`MDS`](https://
 
 [![http://sklearn.apachecn.org/cn/0.19.0/_images/sphx_glr_plot_lle_digits_0101.png](img/12ab1980b4b3f069be032c0d4f1184ed.jpg)](https://scikit-learn.org/stable/auto_examples/manifold/plot_lle_digits.html)
 
-设 ![S](img/12ecd862769bee1e71c75c134b6423bb.jpg) 是相似度矩阵，![X](img/43c1fea57579e54f80c0535bc582626f.jpg) 是 ![n](img/c87d9110f3d32ffa5fa08671e4af11fb.jpg) 个输入点的坐标。差异 ![\hat{d}_{ij}](img/223988a8bef489edcaa2f198e5e3a9a5.jpg) 是某些最优方式所选择的相似度转换。然后，通过 $\sum_{i < j} d_{ij}(X) - \hat{d}_{ij}(X)$ 定义称为 Stress （应力值）的对象。
+设 ![S](img/12ecd862769bee1e71c75c134b6423bb.jpg) 是相似度矩阵，![X](img/43c1fea57579e54f80c0535bc582626f.jpg) 是 ![n](img/c87d9110f3d32ffa5fa08671e4af11fb.jpg) 个输入点的坐标。差异 ![\hat{d}_{ij}](img/223988a8bef489edcaa2f198e5e3a9a5.jpg) 是某些最优方式所选择的相似度转换。然后，通过 $$\sum_{i < j} d_{ij}(X) - \hat{d}_{ij}(X)$$ 定义称为 Stress （应力值）的对象。
 
 ### 2.2.8.1. 度量 MDS
 
@@ -212,7 +212,7 @@ MDS算法有2类：度量和非度量。在 scikit-learn 中， [`MDS`](https://
 
 ### 2.2.8.2. 非度量 MDS
 
-非度量 [`MDS`](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.MDS.html#sklearn.manifold.MDS "sklearn.manifold.MDS") 关注数据的排序。如果 $S_{ij} < S_{jk}$ ，则嵌入应执行 ![d_{ij} &lt; d_{jk}](img/6a0cf5d5f1d5ad90f9713a46fa55111f.jpg) 。这样执行的一个简单算法是在 ![S_{ij}](img/bf95d88f4f17676409c7bab64ba036dc.jpg) 上使用 ![d_{ij}](img/e0d8dbb9574d5eb264279927dcf8baaf.jpg) 的单调回归，产生与 ![S_{ij}](img/bf95d88f4f17676409c7bab64ba036dc.jpg) 相同顺序的差异 ![\hat{d}_{ij}](img/223988a8bef489edcaa2f198e5e3a9a5.jpg) 。
+非度量 [`MDS`](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.MDS.html#sklearn.manifold.MDS "sklearn.manifold.MDS") 关注数据的排序。如果 $$S_{ij} < S_{jk}$$ ，则嵌入应执行 ![d_{ij} &lt; d_{jk}](img/6a0cf5d5f1d5ad90f9713a46fa55111f.jpg) 。这样执行的一个简单算法是在 ![S_{ij}](img/bf95d88f4f17676409c7bab64ba036dc.jpg) 上使用 ![d_{ij}](img/e0d8dbb9574d5eb264279927dcf8baaf.jpg) 的单调回归，产生与 ![S_{ij}](img/bf95d88f4f17676409c7bab64ba036dc.jpg) 相同顺序的差异 ![\hat{d}_{ij}](img/223988a8bef489edcaa2f198e5e3a9a5.jpg) 。
 
 此问题的 a trivial solution（一个平凡解）是把所有点设置到原点上。为了避免这种情况，将差异 ![S_{ij}](img/bf95d88f4f17676409c7bab64ba036dc.jpg) 标准化。
 


### PR DESCRIPTION
gitbook内嵌的mathjax插件所支持的内联公式的格式和一般的markdown内联公式格式有所不同(使用双$代替单$，Kramdown解释器). 已在本地gitbook下测试通过。